### PR TITLE
fix example 6

### DIFF
--- a/examples/expressiontree_example6.cpp
+++ b/examples/expressiontree_example6.cpp
@@ -21,7 +21,7 @@
 * limitations under the Licence.
 */
 
-include <kdl/expressiontree.hpp>
+#include <kdl/expressiontree.hpp>
 #include <fstream>
 #include <boost/timer.hpp>
 


### PR DESCRIPTION
code typo in example 6 (expressiontree_example6.cpp). The code did not compile.
