### PR TITLE
Bug-fix: call 'catkin_package' earlier in catkin.cmake

### DIFF
--- a/catkin.cmake
+++ b/catkin.cmake
@@ -6,6 +6,13 @@ find_package(catkin REQUIRED)
 find_package(orocos_kdl REQUIRED)
 find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  DEPENDS orocos_kdl Eigen
+)
+
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
@@ -32,13 +39,6 @@ set(EXPRESSIONTREE_SRCS
 add_library(${PROJECT_NAME} ${EXPRESSIONTREE_SRCS})
 target_link_libraries(${PROJECT_NAME} 
   ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES} ${Eigen_LIBRARIES})
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
-  DEPENDS orocos_kdl Eigen
-)
-
 
 # BUILDING AND LINKING TESTS
 catkin_add_gtest(${PROJECT_NAME}_test tests/expressiongraph_test.cpp) 


### PR DESCRIPTION
This fixes a bug I encountered when compiling ```expressiongraph``` and a second library called ```giskard``` which depends on it. Basically, the 2nd library could not compile because the macro ```catkin_package``` in ```expression_graph``` appears AFTER the macro ```add_library```. The order of those macros should be flipped.

Here is the output I got:
```shell
CMake Error at /home/georg/ros/giskard/devel/share/expressiongraph/cmake/expressiongraphConfig.cmake:141 (message):
  Project 'giskard' tried to find library 'expressiongraph'.  The library is
  neither a target nor built/installed properly.  Did you compile project
  'expressiongraph'? Did you find_package() it before the subdirectory
  containing its code is included?
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:76 (find_package)
  CMakeLists.txt:4 (find_package)
```

My setup:
- ROS Kinetic on Ubuntu 16.04
- compiling using ```catkin tools```