### PR TITLE
Added missing sign in implementation of NearZero::value().

### DIFF
--- a/include/kdl/expressiontree_double.hpp
+++ b/include/kdl/expressiontree_double.hpp
@@ -918,7 +918,7 @@ public:
 
     virtual R value() {
         double val = this->argument1->value();
-        condition = (tolerance<=val) && (val<=tolerance);
+        condition = (-tolerance<=val) && (val<=tolerance);
         if (condition) {
             return this->argument2->value(); 
         } else {


### PR DESCRIPTION
I think I encountered a small bug in the ```NearZero``` class: The crucial condition did not check whether ```-eps <= val <= eps```, as is stated in the corresponding doc-string. Instead, it tested for ```eps <= val <= eps```.

This pull request adds the missing sign.